### PR TITLE
Blacklist -> Whitelist for Determining Whether to Processing Nodes

### DIFF
--- a/gir2cl.asd
+++ b/gir2cl.asd
@@ -1,5 +1,5 @@
 (defsystem "gir2cl"
-  :version "0.1.0"
+  :version "0.1.1"
   :author "Katherine Cox-Buday <cox.katherine.e@gmail.com>"
   :license "GPLv3"
   :depends-on (#:cxml


### PR DESCRIPTION
This simplifies the logic for skipping unsupported XML nodes by doing
two things:

1. All skipping logic is now centralized into `start-element` and the
   analogue checks have been removed from `end-element`. Instead,
   `end-element` now only checks if `start-element` has instantiated a
   CLOS instance to work with the node.

2. Previously, we had blacklisted interfaces. I haven't done a very
   thorough job of accounting for everything that can be contained in
   a Gir file, so for now, a whitelist of things I have accounted for
   makes more sense.

fixes #2